### PR TITLE
fix(integrations): return GitHub linking to /integrations and refresh…

### DIFF
--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -4,7 +4,8 @@ This project uses environment variables to configure API endpoints. Copy `.env.e
 
 ## Required Environment Variables
 
-- `NEXT_PUBLIC_API_URL`: Base URL for the API server (default: `http://localhost:3001`)
+- `NEXT_PUBLIC_API_BASE_URL`: Base URL for the API server used by all dashboard fetches (e.g. `http://localhost:3001` for local dev, `/api` when proxied by the same host, or `https://staging-api.jataka.ai` for staging). All `fetch` calls in `app/**` and `lib/**` read this value.
+- `NEXT_PUBLIC_GITHUB_APP_NAME`: GitHub App slug used to build the install URL (`https://github.com/apps/<name>/installations/new`). Defaults to `jataka-ai`.
 
 ## Setup
 
@@ -17,5 +18,6 @@ This project uses environment variables to configure API endpoints. Copy `.env.e
 
 ## Notes
 
-- Variables prefixed with `NEXT_PUBLIC_` are exposed to the browser and should not contain sensitive information.
-- The API URL is used throughout the application via the centralized configuration in `lib/api-config.ts`.
+- Variables prefixed with `NEXT_PUBLIC_` are exposed to the browser and must not contain sensitive information.
+- `lib/api-config.ts` is a legacy helper that still references `NEXT_PUBLIC_API_URL`; the rest of the dashboard standardizes on `NEXT_PUBLIC_API_BASE_URL`. Prefer the latter for new code and when configuring deployments.
+- The GitHub App's "Setup URL" should be set to `<dashboard-host>/github/callback` so the OAuth flow returns users to the integrations wizard.

--- a/app/github/callback/page.tsx
+++ b/app/github/callback/page.tsx
@@ -122,7 +122,7 @@ function GithubCallbackInner() {
       if (!res.ok) throw new Error("Link failed");
 
       setStatus("success");
-      setTimeout(() => router.push("/"), 2000);
+      setTimeout(() => router.push("/integrations?github=connected"), 2000);
     } catch (err) {
       console.error(err);
       setStatus("error");
@@ -220,8 +220,8 @@ function GithubCallbackInner() {
 
         {/* Error Return Button */}
         {status === "error" && (
-           <button onClick={() => router.push("/")} className="w-full text-center text-sm text-slate-400 hover:text-white mt-4 underline">
-             Return to Dashboard
+           <button onClick={() => router.push("/integrations")} className="w-full text-center text-sm text-slate-400 hover:text-white mt-4 underline">
+             Return to Integrations
            </button>
         )}
       </div>

--- a/app/integrations/page.tsx
+++ b/app/integrations/page.tsx
@@ -132,8 +132,16 @@ export default function IntegrationsAndSetupPage() {
       const params = new URLSearchParams(window.location.search);
       if (params.get("jira") === "connected") alert("✅ Jira connected!");
       if (params.get("salesforce") === "connected") alert("✅ Salesforce connected!");
-      
-      if (params.has("jira") || params.has("salesforce")) {
+      if (params.get("github") === "connected") {
+        alert("✅ GitHub connected!");
+        checkGithubConnection();
+      }
+      if (params.get("jira") === "error") {
+        const message = params.get("message");
+        alert(`❌ Jira connection failed${message ? `: ${decodeURIComponent(message)}` : ""}`);
+      }
+
+      if (params.has("jira") || params.has("salesforce") || params.has("github")) {
         window.history.replaceState({}, '', "/integrations");
       }
     }


### PR DESCRIPTION
… status

- Redirect GitHub OAuth callback success to /integrations?github=connected
- Handle github=connected and jira=error query params on integrations page
- Align ENV_SETUP with NEXT_PUBLIC_API_BASE_URL
